### PR TITLE
fix(order-form): Fixed syntax error

### DIFF
--- a/application/src/components/order-form-hook/order-form.js
+++ b/application/src/components/order-form-hook/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Line 13: Resolved syntax error by adding 'target' to 'event.target.value'
2. Line 14: Resolved syntax error by adding 'target' to 'event.target.value'

## Purpose
Just a syntax error. Targeting an unidentified node. Order form was not able to complete its task.

## Approach
Now the target is reached so the order can go through.

## Pre-Testing TODOs
_What needs to be done before testing_
- [] Change database values in x collection to y.

## Testing Steps
Navigate to orderform, select any item, and submit by clicking 'Order It!'. Selected items should now appear on the 'view orders' page.

## Learning
No research necessary, just basic syntax knowledge. 

_Links to blog posts, patterns, libraries or addons used to solve this problem_
N/A

_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #1 
